### PR TITLE
Make capable of using Jekyll 2 or 3

### DIFF
--- a/lib/octopress-quote-tag/utils.rb
+++ b/lib/octopress-quote-tag/utils.rb
@@ -9,10 +9,22 @@ module Octopress
           mdext = site.config['markdown_ext']
           txext = site.config['textile_ext']
 
+          markdown_converter = if site.respond_to?(:find_converter_instance)
+            site.find_converter_instance(Jekyll::Converters::Markdown)
+          else
+            site.getConverterImpl(Jekyll::Converters::Markdown)
+          end
+
+          textile_converter = if site.respond_to?(:find_converter_instance)
+            site.find_converter_instance(Jekyll::Converters::Textile)
+          else
+            site.getConverterImpl(Jekyll::Converters::Textile)
+          end
+
           if mdext.include? ext
-            site.getConverterImpl(Jekyll::Converters::Markdown).convert(content)
+            markdown_converter.convert(content)
           elsif txext.include? ext
-            site.getConverterImpl(Jekyll::Converters::Textile).convert(content)
+            textile_converter.convert(content)
           else
             "<p>" + content.strip.gsub(/\n\n/, "<p>\n\n</p>") + "</p>"
           end
@@ -21,4 +33,3 @@ module Octopress
     end
   end
 end
-


### PR DESCRIPTION
For Jekyll 2 use `site.getConverterImpl`
For Jekyll 3 use `site.find_converter_instance`

Based on https://github.com/operasoftware/devopera/pull/269/

Resolves #5
